### PR TITLE
Remove 'Recovery phrase' as a device from the profile screen

### DIFF
--- a/src/services/identity-manager/devices/hooks.ts
+++ b/src/services/identity-manager/devices/hooks.ts
@@ -34,7 +34,9 @@ export const useDevices = () => {
 
   const handleLoadDevices = React.useCallback(async () => {
     if (userNumber) {
-      const existingDevices = await IIConnection.lookupAll(userNumber)
+      const existingDevices = await IIConnection.lookupAuthenticators(
+        userNumber,
+      )
       setDevices(existingDevices)
     }
   }, [setDevices, userNumber])


### PR DESCRIPTION
Story details: https://app.shortcut.com/the-internet-portal/story/1523