### PR TITLE
fix: [sc-5750] google analytics not loading for all regions

### DIFF
--- a/apps/nfid-frontend/craco.config.ts
+++ b/apps/nfid-frontend/craco.config.ts
@@ -47,6 +47,7 @@ const setupCSP = () => {
       ],
       "frame-src": [
         "'self'",
+        "https://*.ic0.app",
         "https://accounts.google.com/gsi/style",
         "https://accounts.google.com/",
       ],


### PR DESCRIPTION
Story details: https://app.shortcut.com/the-internet-portal/story/5750