### PR TITLE
bug([sc-6153]): always upload cache for allure results

### DIFF
--- a/.github/workflows/desktop-tests.yml
+++ b/.github/workflows/desktop-tests.yml
@@ -154,7 +154,7 @@ jobs:
 
       - name: Caching allure-results
         if: always()
-        uses: actions/cache@v3
+        uses: pat-s/always-upload-cache@v3.0.11
         with:
           path: apps/nfid-frontend-e2e/allure-results
           key: allure-results-${{github.RUN_ID}}
@@ -188,7 +188,7 @@ jobs:
         with:
           ref: gh-pages
           path: gh-pages
-      - uses: actions/cache@v3
+      - uses: pat-s/always-upload-cache@v3.0.11
         with:
           path: apps/nfid-frontend-e2e/allure-results
           key: allure-results-${{github.RUN_ID}}


### PR DESCRIPTION
Recently I discovered that failed job doesn't do post-cache step, which is important for reporting, so this fixes it and always saves allure-results