### PR TITLE
fix: [sc-8386] User is able to try to turn on 2FA without new passkeys

### DIFF
--- a/apps/nfid-frontend/src/features/security/index.tsx
+++ b/apps/nfid-frontend/src/features/security/index.tsx
@@ -99,7 +99,9 @@ const ProfileSecurityPage = () => {
           <>
             <span>Two-factor authentication</span>
             <Toggle
-              isDisabled={!devices?.passkeys?.length}
+              isDisabled={
+                !devices?.passkeys?.filter((d) => !d.isLegacyDevice).length
+              }
               isChecked={!!profile?.is2fa}
               onToggle={async (val) => {
                 handleWithLoading(


### PR DESCRIPTION
Story details: https://app.shortcut.com/the-internet-portal/story/8386