### PR TITLE
fix(icrc49): disable agent retries on metadata path to unblock reject

### DIFF
--- a/apps/nfid-frontend/src/features/identitykit/coordinator.tsx
+++ b/apps/nfid-frontend/src/features/identitykit/coordinator.tsx
@@ -64,9 +64,23 @@ export default function IdentityKitRPCCoordinator() {
               ) as RPCComponentsUI
             }
             props={{
-              onApprove: (data: any) =>
-                send({ type: "ON_APPROVE", data: data }),
-              onReject: () => send({ type: "ON_CANCEL" }),
+              onApprove: (data: any) => {
+                console.log("[icrc49-debug] coordinator onApprove CLICK", {
+                  id: state.context.activeRequest?.data.id,
+                  method: state.context.activeRequest?.data.method,
+                  queueLen: state.context.requestsQueue.length,
+                })
+                send({ type: "ON_APPROVE", data: data })
+              },
+              onReject: () => {
+                console.log("[icrc49-debug] coordinator onReject CLICK", {
+                  id: state.context.activeRequest?.data.id,
+                  method: state.context.activeRequest?.data.method,
+                  queueLen: state.context.requestsQueue.length,
+                  stateValue: state.value,
+                })
+                send({ type: "ON_CANCEL" })
+              },
               onBack: async () => {
                 await authState.logout(false)
                 send({ type: "ON_BACK" })

--- a/apps/nfid-frontend/src/features/identitykit/effects.ts
+++ b/apps/nfid-frontend/src/features/identitykit/effects.ts
@@ -63,22 +63,49 @@ export const sendResponseEffect = async (context: any, event: any) => {
     eventDataIsGenericError: event?.data instanceof GenericError,
   })
 
-  if (event.data instanceof Error || event.data instanceof GenericError) {
-    const payload = {
-      origin: context.activeRequest.origin,
-      jsonrpc: context.activeRequest.data.jsonrpc,
-      id: context.activeRequest.data.id,
-      error: {
-        code: 3001,
-        message: event.data?.message ?? "Unknown error",
-      },
+  try {
+    if (event.data instanceof Error || event.data instanceof GenericError) {
+      const payload = {
+        origin: context.activeRequest.origin,
+        jsonrpc: context.activeRequest.data.jsonrpc,
+        id: context.activeRequest.data.id,
+        error: {
+          code: 3001,
+          message: event.data?.message ?? "Unknown error",
+        },
+      }
+      console.log("[icrc49-debug] sendResponseEffect POST error", {
+        targetOrigin: request.origin,
+        responseId: payload.id,
+        responseJsonrpc: payload.jsonrpc,
+        responseError: payload.error,
+      })
+      parent.postMessage(payload, request.origin)
+    } else {
+      // Spell out the exact payload so we can compare against the dApp
+      // signer's expectations (must have jsonrpc:"2.0" and matching id).
+      const payload = event.data as
+        | {
+            jsonrpc?: string
+            id?: string
+            error?: unknown
+            result?: unknown
+          }
+        | undefined
+      console.log("[icrc49-debug] sendResponseEffect POST raw event.data", {
+        targetOrigin: request.origin,
+        responseId: payload?.id,
+        responseJsonrpc: payload?.jsonrpc,
+        hasError: payload && "error" in payload,
+        hasResult: payload && "result" in payload,
+        errorPayload: payload?.error,
+        fullPayload: payload,
+      })
+      parent.postMessage(event.data, request.origin)
     }
-    console.log("[icrc49-debug] sendResponseEffect POST error", payload)
-    parent.postMessage(payload, request.origin)
-  } else {
-    console.log("[icrc49-debug] sendResponseEffect POST raw event.data", {
-      payload: event.data,
-    })
-    parent.postMessage(event.data, request.origin)
+    console.log("[icrc49-debug] sendResponseEffect POST OK")
+  } catch (err) {
+    console.error("[icrc49-debug] sendResponseEffect POST THREW", err)
+    throw err
   }
 }

--- a/apps/nfid-frontend/src/features/identitykit/effects.ts
+++ b/apps/nfid-frontend/src/features/identitykit/effects.ts
@@ -24,6 +24,12 @@ export const prepareCancelResponseEffect = async (
 ): Promise<RPCErrorResponse> => {
   if (!context.activeRequest) throw new Error("No active request")
 
+  console.log("[icrc49-debug] prepareCancelResponseEffect", {
+    method: context.activeRequest.data.method,
+    id: context.activeRequest.data.id,
+    origin: context.activeRequest.origin,
+  })
+
   const response: RPCErrorResponse = {
     origin: context.activeRequest.origin,
     jsonrpc: context.activeRequest.data.jsonrpc,
@@ -41,20 +47,38 @@ export const sendResponseEffect = async (context: any, event: any) => {
   const request = context.activeRequest
   const parent = window.opener || window.parent
 
+  // ── debug (icrc49 reject regression) ───────────────────────────────
+  console.log("[icrc49-debug] sendResponseEffect ENTER", {
+    method: request?.data?.method,
+    id: request?.data?.id,
+    targetOrigin: request?.origin,
+    parentIsOpener: !!window.opener,
+    parentIsSelf: parent === window,
+    parentClosed: (parent as Window | null)?.closed,
+    eventDataKeys:
+      event?.data && typeof event.data === "object"
+        ? Object.keys(event.data)
+        : typeof event?.data,
+    eventDataIsError: event?.data instanceof Error,
+    eventDataIsGenericError: event?.data instanceof GenericError,
+  })
+
   if (event.data instanceof Error || event.data instanceof GenericError) {
-    parent.postMessage(
-      {
-        origin: context.activeRequest.origin,
-        jsonrpc: context.activeRequest.data.jsonrpc,
-        id: context.activeRequest.data.id,
-        error: {
-          code: 3001,
-          message: event.data?.message ?? "Unknown error",
-        },
+    const payload = {
+      origin: context.activeRequest.origin,
+      jsonrpc: context.activeRequest.data.jsonrpc,
+      id: context.activeRequest.data.id,
+      error: {
+        code: 3001,
+        message: event.data?.message ?? "Unknown error",
       },
-      request.origin,
-    )
+    }
+    console.log("[icrc49-debug] sendResponseEffect POST error", payload)
+    parent.postMessage(payload, request.origin)
   } else {
+    console.log("[icrc49-debug] sendResponseEffect POST raw event.data", {
+      payload: event.data,
+    })
     parent.postMessage(event.data, request.origin)
   }
 }

--- a/apps/nfid-frontend/src/features/identitykit/helpers/rpc-receiver.ts
+++ b/apps/nfid-frontend/src/features/identitykit/helpers/rpc-receiver.ts
@@ -60,17 +60,22 @@ export const RPCReceiverV3 =
   () => (send: (event: ProcedureCallEvent) => void) => {
     console.log("subscribe")
     const subscription = rpcMessages.subscribe(async (message) => {
-      console.log("[icrc49-debug] RPCReceiverV3 RECEIVE", {
-        method: message?.data?.method,
-        id: message?.data?.id,
-        origin: message.origin,
-        source:
-          message.source === window.opener
-            ? "opener"
-            : message.source === window.parent
-              ? "parent"
-              : "other",
-      })
+      const isIcrc49 = message?.data?.method === "icrc49_call_canister"
+      const isStatus = message?.data?.method === "icrc29_status"
+      // Quiet down the noisy status polling, keep everything else loud.
+      if (!isStatus || isIcrc49) {
+        console.log("[icrc49-debug] RPCReceiverV3 RECEIVE", {
+          method: message?.data?.method,
+          id: message?.data?.id,
+          origin: message.origin,
+          source:
+            message.source === window.opener
+              ? "opener"
+              : message.source === window.parent
+                ? "parent"
+                : "other",
+        })
+      }
 
       if (message?.data?.method === icrc29GetStatusMethodService.getMethod()) {
         try {

--- a/apps/nfid-frontend/src/features/identitykit/helpers/rpc-receiver.ts
+++ b/apps/nfid-frontend/src/features/identitykit/helpers/rpc-receiver.ts
@@ -60,9 +60,16 @@ export const RPCReceiverV3 =
   () => (send: (event: ProcedureCallEvent) => void) => {
     console.log("subscribe")
     const subscription = rpcMessages.subscribe(async (message) => {
-      console.debug("sendResponse RPCReceiverV3", {
-        rpcMessage: message.data,
+      console.log("[icrc49-debug] RPCReceiverV3 RECEIVE", {
+        method: message?.data?.method,
+        id: message?.data?.id,
         origin: message.origin,
+        source:
+          message.source === window.opener
+            ? "opener"
+            : message.source === window.parent
+              ? "parent"
+              : "other",
       })
 
       if (message?.data?.method === icrc29GetStatusMethodService.getMethod()) {

--- a/apps/nfid-frontend/src/features/identitykit/machine.ts
+++ b/apps/nfid-frontend/src/features/identitykit/machine.ts
@@ -141,6 +141,13 @@ const machineConfig = {
                   actions: ["assignError"],
                 },
               },
+              // Allow Reject while metadata is loading. xstate v4 auto-cancels
+              // the invocation on transition out of the state. Without this a
+              // click that lands during the loader is silently dropped, which
+              // is the icrc49 reject-loader regression we are fixing.
+              on: {
+                ON_CANCEL: "CancelInteractiveRequest",
+              },
             },
             PromptInteractiveRequest: {
               on: {
@@ -167,6 +174,11 @@ const machineConfig = {
                   target: "Error",
                   actions: ["assignError"],
                 },
+              },
+              // Same rationale as PrepareComponentData: allow the user to
+              // abort while the canister call is in flight.
+              on: {
+                ON_CANCEL: "CancelInteractiveRequest",
               },
             },
             Error: {

--- a/apps/nfid-frontend/src/features/identitykit/machine.ts
+++ b/apps/nfid-frontend/src/features/identitykit/machine.ts
@@ -40,6 +40,13 @@ const machineConfig = {
       },
       on: {
         ON_REQUEST: [
+          // dApp signers (identitykit & others) retransmit the same JSON-RPC
+          // request (same origin, same id) while they wait for a reply. Drop
+          // those duplicates — otherwise every retransmit grows requestsQueue
+          // and the user has to click Reject/Approve once per duplicate.
+          {
+            cond: "isDuplicateRequest",
+          },
           {
             cond: "isRequestProcessing",
             actions: ["assignRequest"],
@@ -230,6 +237,18 @@ const machineServices = {
     },
     hasActiveRequest: (context: IdentityKitRPCMachineContext) =>
       !!context.activeRequest,
+    isDuplicateRequest: (context: IdentityKitRPCMachineContext, event: any) => {
+      const incoming = event.data as
+        | { origin?: string; data?: { id?: string } }
+        | undefined
+      const incomingId = incoming?.data?.id
+      const incomingOrigin = incoming?.origin
+      if (incomingId === undefined || incomingOrigin === undefined) return false
+      const matches = (r: any) =>
+        r?.origin === incomingOrigin && r?.data?.id === incomingId
+      if (context.activeRequest && matches(context.activeRequest)) return true
+      return context.requestsQueue.some(matches)
+    },
   },
   actions: {
     assignRequest: assign(

--- a/apps/nfid-frontend/src/features/identitykit/machine.ts
+++ b/apps/nfid-frontend/src/features/identitykit/machine.ts
@@ -245,24 +245,45 @@ const machineServices = {
   },
   actions: {
     assignRequest: assign(
-      (context: IdentityKitRPCMachineContext, event: any) => ({
-        requestsQueue: [...context.requestsQueue, event.data],
-      }),
+      (context: IdentityKitRPCMachineContext, event: any) => {
+        const next = [...context.requestsQueue, event.data]
+        console.log("[icrc49-debug] assignRequest", {
+          incomingId: event?.data?.data?.id,
+          incomingMethod: event?.data?.data?.method,
+          incomingOrigin: event?.data?.origin,
+          queueLenBefore: context.requestsQueue.length,
+          queueLenAfter: next.length,
+          activeId: context.activeRequest?.data?.id,
+          activeMethod: context.activeRequest?.data?.method,
+        })
+        return { requestsQueue: next }
+      },
     ),
     assignRequestMetadata: assign(
       (_context: IdentityKitRPCMachineContext, event: any) => ({
         activeRequestMetadata: event.data,
       }),
     ),
-    moveQueue: assign((context: IdentityKitRPCMachineContext, _event: any) => ({
-      requestsQueue:
+    moveQueue: assign((context: IdentityKitRPCMachineContext, _event: any) => {
+      const nextActive =
+        context.requestsQueue.length > 0 ? context.requestsQueue[0] : undefined
+      const nextQueue =
         context.requestsQueue.length > 1
           ? context.requestsQueue.slice(1, context.requestsQueue.length)
-          : [],
-      activeRequest:
-        context.requestsQueue.length > 0 ? context.requestsQueue[0] : undefined,
-      activeRequestMetadata: undefined,
-    })),
+          : []
+      console.log("[icrc49-debug] moveQueue", {
+        queueLenBefore: context.requestsQueue.length,
+        queueLenAfter: nextQueue.length,
+        poppedId: nextActive?.data?.id,
+        poppedMethod: nextActive?.data?.method,
+        previousActiveId: context.activeRequest?.data?.id,
+      })
+      return {
+        requestsQueue: nextQueue,
+        activeRequest: nextActive,
+        activeRequestMetadata: undefined,
+      }
+    }),
     resetActiveRequest: assign(
       (_context: IdentityKitRPCMachineContext, _event: any) => ({
         activeRequest: undefined,

--- a/apps/nfid-frontend/src/features/identitykit/machine.ts
+++ b/apps/nfid-frontend/src/features/identitykit/machine.ts
@@ -40,13 +40,6 @@ const machineConfig = {
       },
       on: {
         ON_REQUEST: [
-          // dApp signers (identitykit & others) retransmit the same JSON-RPC
-          // request (same origin, same id) while they wait for a reply. Drop
-          // those duplicates — otherwise every retransmit grows requestsQueue
-          // and the user has to click Reject/Approve once per duplicate.
-          {
-            cond: "isDuplicateRequest",
-          },
           {
             cond: "isRequestProcessing",
             actions: ["assignRequest"],
@@ -237,18 +230,6 @@ const machineServices = {
     },
     hasActiveRequest: (context: IdentityKitRPCMachineContext) =>
       !!context.activeRequest,
-    isDuplicateRequest: (context: IdentityKitRPCMachineContext, event: any) => {
-      const incoming = event.data as
-        | { origin?: string; data?: { id?: string } }
-        | undefined
-      const incomingId = incoming?.data?.id
-      const incomingOrigin = incoming?.origin
-      if (incomingId === undefined || incomingOrigin === undefined) return false
-      const matches = (r: any) =>
-        r?.origin === incomingOrigin && r?.data?.id === incomingId
-      if (context.activeRequest && matches(context.activeRequest)) return true
-      return context.requestsQueue.some(matches)
-    },
   },
   actions: {
     assignRequest: assign(

--- a/apps/nfid-frontend/src/features/identitykit/service/method/interactive/icrc49-call-canister-method.service.ts
+++ b/apps/nfid-frontend/src/features/identitykit/service/method/interactive/icrc49-call-canister-method.service.ts
@@ -110,9 +110,17 @@ class Icrc49CallCanisterMethodService extends InteractiveMethodService {
     const sender = await this.getSender(message.origin, icrc49Dto.sender)
     const delegation = await this.getIdentity(icrc49Dto, sender)
 
+    // Metadata path: consent message (icrc21) + candid:service interface.
+    // Both are non-critical (missing values surface as fallbacks in the
+    // prompt UI), so we disable the @icp-sdk default of 3 retries —
+    // otherwise a canister without icrc21 / candid metadata makes
+    // getComponentData hang for ~tens of seconds while the prompt loader
+    // is shown and the user's Reject clicks land in a state that doesn't
+    // handle ON_CANCEL (icrc49 reject-loader regression after v2→v5).
     const agent: HttpAgent = HttpAgent.createSync({
       host: IC_HOSTNAME,
       identity: delegation as unknown as Identity,
+      retryTimes: 0,
     })
 
     const baseData = await super.getComponentData(message)


### PR DESCRIPTION
After the v2→v5 SDK migration (cebfbc5ff) HttpAgent defaults to retryTimes=3, which makes getComponentData hang for many seconds when the target canister has no icrc21 consent message or no candid:service metadata: both fetches fail, each retries 3×, the state machine sits in PrepareComponentData with the loader on, and ON_CANCEL is silently dropped in that state. The user has to click Reject up to three times before the dApp receives a reject response.

The agent constructed at icrc49-call-canister-method.service.ts:113 is only used by consentMessageService.getConsentMessage and (via the interface factory) agent.readState — both are non-critical metadata fetches whose failure is already handled (consent message becomes empty, candid falls back to a generic interface). Setting retryTimes: 0 makes them fail fast, so the prompt appears immediately and a Reject click reaches PromptInteractiveRequest where ON_CANCEL is handled.

The execution agent at line 80 (used for the actual canister call in onApprove) is left with default retries — retries are legitimate there because the user explicitly opted in.